### PR TITLE
fix: update Vercel configuration for API routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "/api/[...path]"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- update the API route handler to use the cached Express app from app.cjs without TypeScript-specific wrappers
- add Vercel rewrite configuration to route all API requests through the catch-all handler

## Testing
- npm run lint *(fails: existing lint issues across the project, including no-var-requires, parsing errors, unused variables, and merge conflict markers)*

------
https://chatgpt.com/codex/tasks/task_e_68e6905fbc4c83229fd93c67655f312b